### PR TITLE
:ambulance: Fix an issue where 'path' keeps previous processed data

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -1,29 +1,7 @@
-const curry = require('./curry')
-const cond = require('./cond')
-const compose = require('./compose')
 const prop = require('./prop')
-const isObject = require('./isObject')
-const identity = require('./identity')
-const T = require('./T')
-const isArray = require('./isArray')
-const map = require('./map')
-const flat = require('./flat')
-const isUndef = require('./isUndef')
-const undef = require('./undef')
-const bind = require('./bind')
-const when = require('./when')
+const reduce = require('./reduce')
+const flip = require('./flip')
 
-const path = curry(
-  ([p, ...ps], args) => cond([
-    [bind(p, isUndef), identity],
-    [isObject, compose(path(ps), prop(p))],
-    [isArray, map(path([p, ...ps]))],
-    [T, undef]
-  ], args)
-)
-
-module.exports = curry(
-  props => compose(
-    when(isArray, flat),
-    path(props))
+module.exports = flip(
+  reduce(flip(prop))
 )


### PR DESCRIPTION
This fix disables path's ability to map over arrays